### PR TITLE
Fix trading station z-fighting when using sodium/indium.

### DIFF
--- a/common/src/main/resources/assets/adorn/models/block/trading_station.json
+++ b/common/src/main/resources/assets/adorn/models/block/trading_station.json
@@ -10,8 +10,8 @@
   "elements": [
     {
       "__comment": "Top",
-      "from": [0, 14, 0],
-      "to": [16, 16, 16],
+      "from": [0.02, 14, 0.02],
+      "to": [15.98, 15.98, 15.98],
       "faces": {
         "up": { "texture": "#top", "cullface": "up" },
         "down": { "texture": "#top" },
@@ -71,8 +71,8 @@
     },
     {
       "__comment": "Cloth",
-      "from": [-0.01, 11.01, -0.01],
-      "to": [16.01, 16.01, 16.01],
+      "from": [0, 11, 0],
+      "to": [16, 16, 16],
       "faces": {
         "up": { "texture": "#cloth_top", "cullface": "up" },
         "east": { "texture": "#cloth_side", "cullface": "east" },


### PR DESCRIPTION
When using sodium on the AOF4 server our users are getting some extreme z-fighting from trading stations. There's also a weird pink strip along some of the edges of the cloth.

![All_of_Fabric_4_29_08_2021_18_18_34](https://user-images.githubusercontent.com/344908/131358622-d50d390c-2604-41d9-ac8d-ecf83cf94c46.png)

I've just tweaked the model a bit. We'll include this fix in the next update of the pack using kubejs, but thought it might be good to submit it as a PR for you too.

![2021-08-30_16 43 17](https://user-images.githubusercontent.com/344908/131358846-f8495aa8-bc94-46e1-b6fd-120274e854a8.png)
