### PR TITLE
Add sink interactions with bottle and bucket

### DIFF
--- a/common/src/main/kotlin/juuxel/adorn/block/KitchenSinkBlock.kt
+++ b/common/src/main/kotlin/juuxel/adorn/block/KitchenSinkBlock.kt
@@ -7,17 +7,29 @@ import net.minecraft.block.BlockState
 import net.minecraft.block.ShapeContext
 import net.minecraft.block.Waterloggable
 import net.minecraft.entity.ai.pathing.NavigationType
+import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.fluid.FluidState
 import net.minecraft.fluid.Fluids
+import net.minecraft.item.ItemStack
+import net.minecraft.item.ItemUsage
+import net.minecraft.item.Items
+import net.minecraft.potion.PotionUtil
+import net.minecraft.potion.Potions
+import net.minecraft.sound.SoundCategory
+import net.minecraft.sound.SoundEvents
 import net.minecraft.state.StateManager
 import net.minecraft.state.property.Properties
+import net.minecraft.util.ActionResult
+import net.minecraft.util.Hand
 import net.minecraft.util.function.BooleanBiFunction
+import net.minecraft.util.hit.BlockHitResult
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
 import net.minecraft.util.shape.VoxelShape
 import net.minecraft.util.shape.VoxelShapes
 import net.minecraft.world.BlockView
 import net.minecraft.world.World
+import net.minecraft.world.event.GameEvent
 
 class KitchenSinkBlock(variant: BlockVariant) : KitchenCounterBlock(variant), Waterloggable {
     init {
@@ -43,6 +55,42 @@ class KitchenSinkBlock(variant: BlockVariant) : KitchenCounterBlock(variant), Wa
         Fluids.EMPTY.defaultState
 
     override fun canPathfindThrough(state: BlockState, world: BlockView, pos: BlockPos, type: NavigationType) = false
+
+    override fun onUse(
+        state: BlockState, world: World, pos: BlockPos, player: PlayerEntity, hand: Hand, hitResult: BlockHitResult?
+    ): ActionResult {
+        val handStack = player.getStackInHand(hand);
+
+        if (handStack.item.equals(Items.POTION) && PotionUtil.getPotion(handStack).equals(Potions.WATER)) {
+            player.setStackInHand(hand, ItemUsage.exchangeStack(handStack, player, ItemStack(Items.GLASS_BOTTLE)))
+            world.playSound(null, pos, SoundEvents.ITEM_BOTTLE_EMPTY, SoundCategory.BLOCKS, 1.0f, 1.0f)
+            world.emitGameEvent(null, GameEvent.FLUID_PLACE, pos)
+            return ActionResult.CONSUME
+        }
+
+        if (state[WATERLOGGED]) {
+            if (handStack.item.equals(Items.GLASS_BOTTLE)) {
+                player.setStackInHand(hand, ItemUsage.exchangeStack(handStack, player, PotionUtil.setPotion(ItemStack(Items.POTION), Potions.WATER)))
+                world.playSound(null, pos, SoundEvents.ITEM_BOTTLE_FILL, SoundCategory.BLOCKS, 1.0f, 1.0f)
+                world.emitGameEvent(null, GameEvent.FLUID_PICKUP, pos)
+                return ActionResult.CONSUME
+            }
+            if (handStack.item.equals(Items.BUCKET)) {
+                player.setStackInHand(hand, ItemUsage.exchangeStack(handStack, player, ItemStack(Items.WATER_BUCKET)))
+                world.playSound(null, pos, SoundEvents.ITEM_BUCKET_FILL, SoundCategory.BLOCKS, 1.0f, 1.0f)
+                world.emitGameEvent(null, GameEvent.FLUID_PICKUP, pos)
+                return ActionResult.CONSUME
+            }
+            if (handStack.item.equals(Items.WATER_BUCKET)) {
+                player.setStackInHand(hand, ItemUsage.exchangeStack(handStack, player, ItemStack(Items.BUCKET)))
+                world.playSound(null, pos, SoundEvents.ITEM_BUCKET_EMPTY, SoundCategory.BLOCKS, 1.0f, 1.0f)
+                world.emitGameEvent(null, GameEvent.FLUID_PLACE, pos)
+                return ActionResult.CONSUME
+            }
+        }
+
+        return ActionResult.PASS
+    }
 
     companion object {
         private val WATERLOGGED = Properties.WATERLOGGED


### PR DESCRIPTION
* Empty water bottles into an empty or filled sink;
* Empty water buckets into a filled sink;
* Fill bottles and buckets from a filled sink without emptying it;
* Shift+right click with empty bucket to take water from a filled sink.

It seemed odd to me that I need to make a water source in the kitchen when I have a sink, so I made this.