### PR TITLE
Add stone torch dynamic light data.

### DIFF
--- a/common/src/main/resources/assets/adorn/dynamiclights/item/stone_torch.json
+++ b/common/src/main/resources/assets/adorn/dynamiclights/item/stone_torch.json
@@ -1,0 +1,9 @@
+{
+  "match": {
+    "items": "adorn:stone_torch"
+  },
+  "luminance": {
+    "type": "block_self"
+  },
+  "water_sensitive": true
+}


### PR DESCRIPTION
For a long time LambDynamicLights has provided a JSON file for dynamic lighting of Adorn's stone torch with the goal to be similar to its own default data for Vanilla torches.

Though I think it might make more sense if that file is directly in Adorn, and given it's just a JSON file I figured it shouldn't be too much of a constraint.

This file tells LambDynamicLights that, for every Adorn stone torch items, it should:
- use the same luminance value as the stone torch block
- and is sensitive in water, so it can turn off underwater since torches cannot be placed underwater.

I've put it into the common assets since some LambDynamicLights' NeoForge forks provide the same data-driven feature.