### PR TITLE
Fixed advancements using tags for 1.21

### DIFF
--- a/common/src/main/resources/data/adorn/advancement/bench.json
+++ b/common/src/main/resources/data/adorn/advancement/bench.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:benches"
+            "items": "#adorn:benches"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/candlelit_lantern.json
+++ b/common/src/main/resources/data/adorn/advancement/candlelit_lantern.json
@@ -10,7 +10,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:candlelit_lanterns" }
+          { "items": "#adorn:candlelit_lanterns" }
         ]
       }
     }

--- a/common/src/main/resources/data/adorn/advancement/chimney.json
+++ b/common/src/main/resources/data/adorn/advancement/chimney.json
@@ -16,7 +16,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:regular_chimneys" }
+          { "items": "#adorn:regular_chimneys" }
         ]
       }
     }

--- a/common/src/main/resources/data/adorn/advancement/coffee_table.json
+++ b/common/src/main/resources/data/adorn/advancement/coffee_table.json
@@ -16,7 +16,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:coffee_tables" }
+          { "items": "#adorn:coffee_tables" }
         ]
       }
     }

--- a/common/src/main/resources/data/adorn/advancement/crate.json
+++ b/common/src/main/resources/data/adorn/advancement/crate.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:filled_crates"
+            "items": "#adorn:filled_crates"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/drawer.json
+++ b/common/src/main/resources/data/adorn/advancement/drawer.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:drawers"
+            "items": "#adorn:drawers"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/everything.json
+++ b/common/src/main/resources/data/adorn/advancement/everything.json
@@ -18,7 +18,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:benches"
+            "items": "#adorn:benches"
           }
         ]
       }
@@ -37,7 +37,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:candlelit_lanterns" }
+          { "items": "#adorn:candlelit_lanterns" }
         ]
       }
     },
@@ -56,7 +56,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:chairs"
+            "items": "#adorn:chairs"
           }
         ]
       }
@@ -65,7 +65,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:regular_chimneys" }
+          { "items": "#adorn:regular_chimneys" }
         ]
       }
     },
@@ -74,7 +74,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:crates"
+            "items": "#adorn:crates"
           }
         ]
       }
@@ -83,7 +83,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:coffee_tables" }
+          { "items": "#adorn:coffee_tables" }
         ]
       }
     },
@@ -92,7 +92,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:drawers"
+            "items": "#adorn:drawers"
           }
         ]
       }
@@ -102,7 +102,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_counters"
+            "items": "#adorn:kitchen_counters"
           }
         ]
       }
@@ -112,7 +112,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_cupboards"
+            "items": "#adorn:kitchen_cupboards"
           }
         ]
       }
@@ -122,7 +122,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_sinks"
+            "items": "#adorn:kitchen_sinks"
           }
         ]
       }
@@ -142,7 +142,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:platforms"
+            "items": "#adorn:platforms"
           }
         ]
       }
@@ -152,7 +152,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:posts"
+            "items": "#adorn:posts"
           }
         ]
       }
@@ -161,7 +161,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:prismarine_chimneys" }
+          { "items": "#adorn:prismarine_chimneys" }
         ]
       }
     },
@@ -170,7 +170,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:shelves"
+            "items": "#adorn:shelves"
           }
         ]
       }
@@ -180,7 +180,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:sofas"
+            "items": "#adorn:sofas"
           }
         ]
       }
@@ -190,7 +190,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:steps"
+            "items": "#adorn:steps"
           }
         ]
       }
@@ -219,7 +219,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:tables" }
+          { "items": "#adorn:tables" }
         ]
       }
     },
@@ -227,7 +227,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:table_lamps" }
+          { "items": "#adorn:table_lamps" }
         ]
       }
     },

--- a/common/src/main/resources/data/adorn/advancement/kitchen_counter.json
+++ b/common/src/main/resources/data/adorn/advancement/kitchen_counter.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_counters"
+            "items": "#adorn:kitchen_counters"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/kitchen_cupboard.json
+++ b/common/src/main/resources/data/adorn/advancement/kitchen_cupboard.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_cupboards"
+            "items": "#adorn:kitchen_cupboards"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/kitchen_sink.json
+++ b/common/src/main/resources/data/adorn/advancement/kitchen_sink.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:kitchen_sinks"
+            "items": "#adorn:kitchen_sinks"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/platform.json
+++ b/common/src/main/resources/data/adorn/advancement/platform.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:platforms"
+            "items": "#adorn:platforms"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/post.json
+++ b/common/src/main/resources/data/adorn/advancement/post.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:posts"
+            "items": "#adorn:posts"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/prismarine_chimney.json
+++ b/common/src/main/resources/data/adorn/advancement/prismarine_chimney.json
@@ -16,7 +16,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:prismarine_chimneys" }
+          { "items": "#adorn:prismarine_chimneys" }
         ]
       }
     }

--- a/common/src/main/resources/data/adorn/advancement/shelf.json
+++ b/common/src/main/resources/data/adorn/advancement/shelf.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:shelves"
+            "items": "#adorn:shelves"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/sofa.json
+++ b/common/src/main/resources/data/adorn/advancement/sofa.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:sofas"
+            "items": "#adorn:sofas"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/step.json
+++ b/common/src/main/resources/data/adorn/advancement/step.json
@@ -17,7 +17,7 @@
       "conditions": {
         "items": [
           {
-            "tag": "adorn:steps"
+            "items": "#adorn:steps"
           }
         ]
       }

--- a/common/src/main/resources/data/adorn/advancement/table.json
+++ b/common/src/main/resources/data/adorn/advancement/table.json
@@ -16,7 +16,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:tables" }
+          { "items": "#adorn:tables" }
         ]
       }
     }

--- a/common/src/main/resources/data/adorn/advancement/table_lamp.json
+++ b/common/src/main/resources/data/adorn/advancement/table_lamp.json
@@ -16,7 +16,7 @@
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
-          { "tag": "adorn:table_lamps" }
+          { "items": "#adorn:table_lamps" }
         ]
       }
     }


### PR DESCRIPTION
Fixed advancements that were using tags under the criteria minecraft:inventory_changed. This will stop the user from getting spammed with a handful of advancements when their inventory is changed for the first time.