### PR TITLE
Fix #332 Let living entities climb trapdoors above stone ladders

### DIFF
--- a/common/src/main/java/juuxel/adorn/commonmixin/LivingEntityMixin.java
+++ b/common/src/main/java/juuxel/adorn/commonmixin/LivingEntityMixin.java
@@ -1,0 +1,20 @@
+package juuxel.adorn.commonmixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(LivingEntity.class)
+abstract class LivingEntityMixin {
+
+    @Redirect(method = "canEnterTrapdoor", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/BlockState;isOf(Lnet/minecraft/block/Block;)Z"))
+    public boolean adorn_isTrapdoor(BlockState state, Block block) {
+        return state.isIn(TagKey.of(RegistryKeys.BLOCK, Identifier.of("c", "ladders")));
+    }
+}

--- a/common/src/main/resources/data/c/tags/block/ladders.json
+++ b/common/src/main/resources/data/c/tags/block/ladders.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "minecraft:ladder",
+      "adorn:stone_ladder"
+    ]
+  }
+  

--- a/common/src/main/resources/mixins.adorn.common.json
+++ b/common/src/main/resources/mixins.adorn.common.json
@@ -8,6 +8,7 @@
     "BlockMixin",
     "BubbleColumnBlockMixin",
     "FenceGateBlockMixin",
+    "LivingEntityMixin",
     "ItemStackMixin"
   ],
   "client": [


### PR DESCRIPTION
Added a mixin to `LivingEntity` that redirects the `BlockEntity.isOf()` to `BlockEntity.isIn()` and adds a tag for "c:trapdoors"